### PR TITLE
feat(server): add duplicate transaction detection and ingestion stats

### DIFF
--- a/server/app/api/endpoints.py
+++ b/server/app/api/endpoints.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import uuid
+from fastapi.concurrency import run_in_threadpool
 from fastapi import APIRouter, UploadFile, File, Depends, HTTPException
 from app.api.dependencies import verify_cbac, rate_limiter
 from app.api.pii import sanitize_transaction_row
@@ -45,14 +46,28 @@ async def upload_transactions(
     # 2. Generate a tracking ID
     task_id = str(uuid.uuid4())
 
-    # 3. Process batch with duplicate detection and ingestion stats
-    processing_stats = await process_transaction_batch(batch, str(context["user_id"]))
+    # 3. Process batch with duplicate detection and ingestion stats in a thread.
+    processing_stats = await run_in_threadpool(
+        process_transaction_batch,
+        batch,
+        str(context["user_id"]),
+    )
     
     # 4. Log PII modifications for compliance/forensics
     await log_audit_events(context["user_id"], audit_logs, task_id)
+
+    if processing_stats.get("error"):
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "task_id": task_id,
+                "message": "Transaction batch processing failed.",
+                "error": processing_stats["error"],
+            },
+        )
     
     return {
-        "status": "completed" if not processing_stats.get("error") else "failed",
+        "status": "completed",
         "task_id": task_id,
         "rows_received": len(batch),
         "rows_processed": processing_stats.get("processed", 0),
@@ -67,5 +82,4 @@ async def upload_transactions(
             f"{processing_stats.get('duplicate_count', 0)} duplicates skipped, "
             f"and {processing_stats.get('missing_transaction_id', 0)} rows missing transaction_id."
         ),
-        "error": processing_stats.get("error"),
     }

--- a/server/app/api/endpoints.py
+++ b/server/app/api/endpoints.py
@@ -1,7 +1,7 @@
 import csv
 import io
 import uuid
-from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, BackgroundTasks
+from fastapi import APIRouter, UploadFile, File, Depends, HTTPException
 from app.api.dependencies import verify_cbac, rate_limiter
 from app.api.pii import sanitize_transaction_row
 from app.worker.tasks import process_transaction_batch
@@ -15,15 +15,15 @@ async def log_audit_events(user_id: str, logs: list, task_id: str):
 
 @router.post("/upload")
 async def upload_transactions(
-    background_tasks: BackgroundTasks,
     file: UploadFile = File(...),
     context: dict = Depends(verify_cbac),
     _ = Depends(rate_limiter)
 ):
     """
-    Expects a CSV upload. Parses and dispatches records for background processing.
+    Expects a CSV upload. Parses and processes records with ingestion stats.
     """
-    if not file.filename.endswith(".csv"):
+    filename = file.filename or ""
+    if not filename.endswith(".csv"):
         raise HTTPException(status_code=400, detail="Invalid file type. Only .csv is allowed.")
         
     content = await file.read()
@@ -35,7 +35,7 @@ async def upload_transactions(
         raise HTTPException(status_code=400, detail=f"Failed to parse CSV: {str(e)}")
         
     batch = []
-    audit_logs = []
+    audit_logs: list[dict] = []
     
     # 1. PII Detection & Tokenization
     for row in reader:
@@ -44,21 +44,28 @@ async def upload_transactions(
         
     # 2. Generate a tracking ID
     task_id = str(uuid.uuid4())
-        
-    # 3. Dispatch clean data to FastAPI background tasks
-    background_tasks.add_task(
-        process_transaction_batch, 
-        batch, 
-        str(context["user_id"])
-    )
+
+    # 3. Process batch with duplicate detection and ingestion stats
+    processing_stats = await process_transaction_batch(batch, str(context["user_id"]))
     
     # 4. Log PII modifications for compliance/forensics
     await log_audit_events(context["user_id"], audit_logs, task_id)
     
     return {
-        "status": "processing",
+        "status": "completed" if not processing_stats.get("error") else "failed",
         "task_id": task_id,
         "rows_received": len(batch),
+        "rows_processed": processing_stats.get("processed", 0),
+        "rows_skipped": processing_stats.get("skipped", 0),
+        "duplicate_rows": processing_stats.get("duplicate_count", 0),
+        "duplicate_in_batch": processing_stats.get("duplicate_in_batch", 0),
+        "duplicate_existing": processing_stats.get("duplicate_existing", 0),
+        "missing_transaction_id": processing_stats.get("missing_transaction_id", 0),
         "pii_entities_secured": len(audit_logs),
-        "message": f"Successfully queued batch of {len(batch)} transactions for background processing."
+        "message": (
+            f"Processed batch with {processing_stats.get('processed', 0)} inserts, "
+            f"{processing_stats.get('duplicate_count', 0)} duplicates skipped, "
+            f"and {processing_stats.get('missing_transaction_id', 0)} rows missing transaction_id."
+        ),
+        "error": processing_stats.get("error"),
     }

--- a/server/app/worker/tasks.py
+++ b/server/app/worker/tasks.py
@@ -1,5 +1,6 @@
 import dateutil.parser
 import logging
+from typing import Any
 from sqlalchemy import text
 from app.db.session import SessionLocal
 from app.models.schema import Transaction, SemanticMemory
@@ -8,15 +9,57 @@ from app.worker.stubs import generate_embedding
 logger = logging.getLogger(__name__)
 
 async def process_transaction_batch(batch: list[dict], user_id: str):
+    stats: dict[str, Any] = {
+        "received": len(batch),
+        "processed": 0,
+        "skipped": 0,
+        "duplicate_count": 0,
+        "duplicate_in_batch": 0,
+        "duplicate_existing": 0,
+        "missing_transaction_id": 0,
+    }
+
     db = SessionLocal()
     try:
         # Enforce application context for RLS
         db.execute(text(f"SET app.current_user_id = '{user_id}'"))
+
+        unique_rows = []
+        seen_transaction_ids = set()
+        for row in batch:
+            txn_id = row.get("transaction_id")
+            if not txn_id:
+                stats["missing_transaction_id"] += 1
+                continue
+
+            if txn_id in seen_transaction_ids:
+                stats["duplicate_in_batch"] += 1
+                continue
+
+            seen_transaction_ids.add(txn_id)
+            unique_rows.append(row)
+
+        existing_ids = set()
+        if unique_rows:
+            candidate_ids = [row["transaction_id"] for row in unique_rows]
+            existing_rows = (
+                db.query(Transaction.transaction_id)
+                .filter(Transaction.transaction_id.in_(candidate_ids))
+                .all()
+            )
+            existing_ids = {row[0] for row in existing_rows}
+
+        rows_to_insert = [
+            row for row in unique_rows if row["transaction_id"] not in existing_ids
+        ]
+        stats["duplicate_existing"] = len(existing_ids)
+        stats["duplicate_count"] = stats["duplicate_in_batch"] + stats["duplicate_existing"]
+        stats["skipped"] = stats["duplicate_count"] + stats["missing_transaction_id"]
         
         transactions_to_save = []
         memories_to_save = []
-        
-        for row in batch:
+
+        for row in rows_to_insert:
             txn_id = row.get("transaction_id")
             amount = float(row.get("amount", 0.0))
             merchant = row.get("merchant", "")
@@ -49,16 +92,33 @@ async def process_transaction_batch(batch: list[dict], user_id: str):
                 embedding=embedding
             )
             memories_to_save.append(mem)
-            
+
         # Bulk save
-        db.bulk_save_objects(transactions_to_save)
-        db.bulk_save_objects(memories_to_save)
+        if transactions_to_save:
+            db.bulk_save_objects(transactions_to_save)
+        if memories_to_save:
+            db.bulk_save_objects(memories_to_save)
         db.commit()
-        logger.info(f"Successfully processed batch for user {user_id}")
-        
+
+        stats["processed"] = len(transactions_to_save)
+        logger.info(
+            "Batch processed for user %s | received=%d processed=%d skipped=%d duplicates=%d "
+            "(batch=%d, existing=%d, missing_id=%d)",
+            user_id,
+            stats["received"],
+            stats["processed"],
+            stats["skipped"],
+            stats["duplicate_count"],
+            stats["duplicate_in_batch"],
+            stats["duplicate_existing"],
+            stats["missing_transaction_id"],
+        )
+        return stats
+
     except Exception as exc:
         db.rollback()
         logger.error(f"Error processing batch for user {user_id}: {exc}")
         # In a real app, you might want to retry here or move to a dead-letter queue
+        return {**stats, "error": str(exc)}
     finally:
         db.close()

--- a/server/app/worker/tasks.py
+++ b/server/app/worker/tasks.py
@@ -1,14 +1,16 @@
 import dateutil.parser
 import logging
+import uuid
 from typing import Any
 from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import insert
 from app.db.session import SessionLocal
 from app.models.schema import Transaction, SemanticMemory
 from app.worker.stubs import generate_embedding
 
 logger = logging.getLogger(__name__)
 
-async def process_transaction_batch(batch: list[dict], user_id: str):
+def process_transaction_batch(batch: list[dict], user_id: str) -> dict[str, Any]:
     stats: dict[str, Any] = {
         "received": len(batch),
         "processed": 0,
@@ -21,8 +23,16 @@ async def process_transaction_batch(batch: list[dict], user_id: str):
 
     db = SessionLocal()
     try:
+        try:
+            user_uuid = uuid.UUID(str(user_id))
+        except (ValueError, TypeError) as exc:
+            return {**stats, "error": f"Invalid user_id UUID: {exc}"}
+
         # Enforce application context for RLS
-        db.execute(text(f"SET app.current_user_id = '{user_id}'"))
+        db.execute(
+            text("SELECT set_config('app.current_user_id', :user_id, true)"),
+            {"user_id": str(user_uuid)},
+        )
 
         unique_rows = []
         seen_transaction_ids = set()
@@ -39,27 +49,7 @@ async def process_transaction_batch(batch: list[dict], user_id: str):
             seen_transaction_ids.add(txn_id)
             unique_rows.append(row)
 
-        existing_ids = set()
-        if unique_rows:
-            candidate_ids = [row["transaction_id"] for row in unique_rows]
-            existing_rows = (
-                db.query(Transaction.transaction_id)
-                .filter(Transaction.transaction_id.in_(candidate_ids))
-                .all()
-            )
-            existing_ids = {row[0] for row in existing_rows}
-
-        rows_to_insert = [
-            row for row in unique_rows if row["transaction_id"] not in existing_ids
-        ]
-        stats["duplicate_existing"] = len(existing_ids)
-        stats["duplicate_count"] = stats["duplicate_in_batch"] + stats["duplicate_existing"]
-        stats["skipped"] = stats["duplicate_count"] + stats["missing_transaction_id"]
-        
-        transactions_to_save = []
-        memories_to_save = []
-
-        for row in rows_to_insert:
+        for row in unique_rows:
             txn_id = row.get("transaction_id")
             amount = float(row.get("amount", 0.0))
             merchant = row.get("merchant", "")
@@ -67,44 +57,48 @@ async def process_transaction_batch(batch: list[dict], user_id: str):
             date_str = row.get("date")
             try:
                 txn_date = dateutil.parser.parse(date_str) if date_str else None
-            except:
+            except (ValueError, TypeError, OverflowError):
                 txn_date = None
-            
-            # Create transaction object
-            txn = Transaction(
-                user_id=user_id,
-                transaction_id=txn_id,
-                amount=amount,
-                merchant=merchant,
-                date=txn_date
+
+            # Race-safe idempotency: DB enforces uniqueness and ignores conflicts.
+            tx_insert_result = db.execute(
+                insert(Transaction)
+                .values(
+                    user_id=user_uuid,
+                    transaction_id=txn_id,
+                    amount=amount,
+                    merchant=merchant,
+                    date=txn_date,
+                )
+                .on_conflict_do_nothing(index_elements=["transaction_id"])
             )
-            transactions_to_save.append(txn)
-            
-            # Use the sanitized description for semantic embeddings
+
+            if tx_insert_result.rowcount == 0:
+                stats["duplicate_existing"] += 1
+                continue
+
+            # Use the sanitized description for semantic embeddings.
             content = f"Spent ${amount} at {merchant}. Description: {description} on {txn_date}"
             embedding = generate_embedding(content)
-            
-            # Create semantic memory object
+
             mem = SemanticMemory(
-                user_id=user_id,
+                user_id=user_uuid,
                 transaction_id=txn_id,
                 content=content,
-                embedding=embedding
+                embedding=embedding,
             )
-            memories_to_save.append(mem)
+            db.add(mem)
+            stats["processed"] += 1
 
-        # Bulk save
-        if transactions_to_save:
-            db.bulk_save_objects(transactions_to_save)
-        if memories_to_save:
-            db.bulk_save_objects(memories_to_save)
+        stats["duplicate_count"] = stats["duplicate_in_batch"] + stats["duplicate_existing"]
+        stats["skipped"] = stats["duplicate_count"] + stats["missing_transaction_id"]
+
         db.commit()
 
-        stats["processed"] = len(transactions_to_save)
         logger.info(
             "Batch processed for user %s | received=%d processed=%d skipped=%d duplicates=%d "
             "(batch=%d, existing=%d, missing_id=%d)",
-            user_id,
+            user_uuid,
             stats["received"],
             stats["processed"],
             stats["skipped"],


### PR DESCRIPTION
Fixes #9

## Summary
This PR hardens the upload ingestion path and addresses key concerns around security, concurrency, idempotency, and error handling.

## Changes
- Replaced SQL string interpolation for RLS context assignment with a bound parameter via `set_config`
- Added strict UUID validation/coercion for `user_id` before DB session context setup
- Converted `process_transaction_batch` to synchronous (it performs sync DB I/O and embedding generation)
- Offloaded ingestion from async endpoint using `run_in_threadpool` to avoid event-loop blocking
- Replaced pre-select duplicate strategy with race-safe DB conflict handling using PostgreSQL `ON CONFLICT DO NOTHING`
- Preserved ingestion stats and duplicate observability logging
- Return HTTP 500 on ingestion failure instead of HTTP 200 with embedded error text

## Acceptance Criteria
- [x] Duplicate records are detected by `transaction_id` before insert
- [x] Duplicate rows are skipped safely without breaking the full batch
- [x] API response includes processed/skipped/duplicate counts
- [x] Logging includes duplicate summary for observability

## Files
- `server/app/worker/tasks.py`
- `server/app/api/endpoints.py`