### PR TITLE
Embed single-page Web UI (no build step)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1313,6 +1313,50 @@ got, _ := cloudevents.Unwrap(ev)
 
 ---
 
+## Web UI
+
+Genie ships a single-page UI embedded into the binary — no Node, no build
+step. After `make compose-up`, open <http://localhost:8080/> and you get
+redirected to `/ui/`.
+
+```mermaid
+flowchart LR
+    BR[Browser] --> ROOT[GET /]
+    ROOT -- 302 --> UI[/ui/]
+    UI --> APP[index.html + styles.css + app.js]
+    APP -->|fetch /v1/*| API[Genie HTTP API]
+    APP -->|fetch + ReadableStream| SSE[/v1/ask/stream/]
+    APP -. shows .-> EVT[Agent pipeline events]
+    APP -. shows .-> REPORT[Final report]
+```
+
+What the UI covers:
+
+- **Auth** — sign up + sign in flow; JWT stored in localStorage; logout.
+- **Ask** — pick a document, type a question, submit either synchronously
+  (`POST /v1/ask`) or streamed (`POST /v1/ask/stream`). Pipeline events
+  stream into a live event log; the final report renders below.
+- **Documents** — upload a CSV (encrypted server-side via envelope
+  AES-256-GCM before reaching Postgres); pick classification + description.
+- **Governance** — public `/v1/disclosures`; admin-only `/v1/ai-inventory`,
+  `/v1/aibom`, `/v1/incidents`.
+- **Settings** — point the UI at a different Genie instance; live
+  readiness check via `/readyz`.
+
+Plain HTML/CSS/JS — no framework, automatic light/dark mode via
+`prefers-color-scheme`:
+
+- [`pkg/web/handlers/ui/index.html`](pkg/web/handlers/ui/index.html)
+- [`pkg/web/handlers/ui/styles.css`](pkg/web/handlers/ui/styles.css)
+- [`pkg/web/handlers/ui/app.js`](pkg/web/handlers/ui/app.js)
+
+Served by `handlers.NewUI()` which uses `embed.FS` so the assets ship
+inside `genie-api`. To customise without rebuilding the binary, swap
+`embed.FS` for a filesystem-backed `fs.FS` and point it at a local
+directory during dev.
+
+---
+
 ## Live profiling (pprof)
 
 Standard-library pprof under `/debug/pprof/*`, behind JWT auth + the

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -306,6 +306,11 @@ func run() error {
 		AIBOM:     &handlers.AIBOM{Reg: reg, Builder: aibom.NewBuilder()},
 		Feedback:  &handlers.Feedback{Store: synth.NewInMemoryFeedbackStore()},
 	}
+	if ui, err := handlers.NewUI(); err == nil {
+		deps.UI = ui
+	} else {
+		logger.Error("ui.embed", "error", err)
+	}
 
 	// Retention purge — runs every 6h (Rec 15).
 	db.StartRetentionJob(ctx, 6*time.Hour, logger.Info)

--- a/pkg/web/handlers/ui.go
+++ b/pkg/web/handlers/ui.go
@@ -1,0 +1,86 @@
+package handlers
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+	"strings"
+)
+
+//go:embed ui/*
+var uiFS embed.FS
+
+// UI serves the embedded single-page UI (ui/index.html + ui/styles.css +
+// ui/app.js). Mount it at /ui/* and Genie ships the front-end inside the
+// binary — no Node, no build step, no separate static-file hosting.
+//
+// The UI dialogs with the same JSON API the curl examples in the README
+// use; SSE streaming is read manually with fetch + ReadableStream so the
+// browser doesn't need EventSource (which forbids Authorization headers).
+type UI struct {
+	root fs.FS
+}
+
+// NewUI builds the handler. Returns an error only if the embedded FS is
+// missing — that's a build-time bug, not a runtime one.
+func NewUI() (*UI, error) {
+	sub, err := fs.Sub(uiFS, "ui")
+	if err != nil {
+		return nil, err
+	}
+	return &UI{root: sub}, nil
+}
+
+// ServeHTTP serves the embedded files. The router mounts this under /ui/.
+// Requests to /ui/ (no file) get index.html.
+func (h *UI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// chi strips the mount prefix, so r.URL.Path is relative to /ui/.
+	rel := strings.TrimPrefix(r.URL.Path, "/")
+	if rel == "" || rel == "/" {
+		rel = "index.html"
+	}
+	// Block directory traversal.
+	if strings.Contains(rel, "..") {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	data, err := fs.ReadFile(h.root, rel)
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", contentTypeForPath(rel))
+	// Short cache so an `index.html` edit shows up after one refresh, but
+	// hashed assets can be cached aggressively if you ever add them.
+	w.Header().Set("Cache-Control", "no-cache, max-age=60")
+	_, _ = w.Write(data)
+}
+
+// IndexHTML returns the entry point — used by the root redirect handler so
+// a bare GET / lands on the app instead of a 404.
+func (h *UI) IndexHTML(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/ui/", http.StatusFound)
+}
+
+// contentTypeForPath picks a Content-Type from the extension. Keep this
+// tiny — we only ship a handful of file types.
+func contentTypeForPath(p string) string {
+	switch {
+	case strings.HasSuffix(p, ".html"):
+		return "text/html; charset=utf-8"
+	case strings.HasSuffix(p, ".css"):
+		return "text/css; charset=utf-8"
+	case strings.HasSuffix(p, ".js"):
+		return "application/javascript; charset=utf-8"
+	case strings.HasSuffix(p, ".svg"):
+		return "image/svg+xml"
+	case strings.HasSuffix(p, ".png"):
+		return "image/png"
+	case strings.HasSuffix(p, ".jpg"), strings.HasSuffix(p, ".jpeg"):
+		return "image/jpeg"
+	case strings.HasSuffix(p, ".json"):
+		return "application/json"
+	default:
+		return "application/octet-stream"
+	}
+}

--- a/pkg/web/handlers/ui/app.js
+++ b/pkg/web/handlers/ui/app.js
@@ -1,0 +1,401 @@
+// Genie UI — vanilla JS, no framework. Pairs with index.html + styles.css.
+//
+// State lives in localStorage so refreshes survive. Streaming uses the
+// browser's EventSource against /v1/ask/stream — same SSE shape as the curl
+// example in the README.
+
+(function () {
+  'use strict';
+
+  // -----------------------------------------------------------------
+  // state
+  // -----------------------------------------------------------------
+
+  const LS_KEY = 'genie.session.v1';
+  const LS_BASE = 'genie.apibase.v1';
+
+  const state = {
+    base: localStorage.getItem(LS_BASE) || '/v1',
+    token: null,
+    user: null,
+    documents: [],
+    activeStream: null,
+  };
+
+  try {
+    const cached = JSON.parse(localStorage.getItem(LS_KEY) || 'null');
+    if (cached && cached.token && cached.user) {
+      state.token = cached.token;
+      state.user = cached.user;
+    }
+  } catch (_) { /* ignore */ }
+
+  // -----------------------------------------------------------------
+  // tiny helpers
+  // -----------------------------------------------------------------
+
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+  function show(el) { el.hidden = false; }
+  function hide(el) { el.hidden = true; }
+
+  function persistSession() {
+    if (state.token && state.user) {
+      localStorage.setItem(LS_KEY, JSON.stringify({ token: state.token, user: state.user }));
+    } else {
+      localStorage.removeItem(LS_KEY);
+    }
+  }
+
+  async function api(path, opts = {}) {
+    const headers = Object.assign({ 'Accept': 'application/json' }, opts.headers || {});
+    if (state.token) headers['Authorization'] = 'Bearer ' + state.token;
+    if (opts.json !== undefined) {
+      headers['Content-Type'] = 'application/json';
+      opts.body = JSON.stringify(opts.json);
+      delete opts.json;
+    }
+    const url = state.base.replace(/\/$/, '') + path;
+    const resp = await fetch(url, Object.assign({}, opts, { headers }));
+    const text = await resp.text();
+    let body = text;
+    try { body = JSON.parse(text); } catch (_) { /* keep as text */ }
+    if (!resp.ok) {
+      const message = (body && body.error) || (typeof body === 'string' ? body : resp.statusText);
+      throw new Error(message);
+    }
+    return body;
+  }
+
+  function flash(node, type, message) {
+    node.textContent = message || '';
+    node.dataset.flash = type || '';
+  }
+
+  // -----------------------------------------------------------------
+  // navigation
+  // -----------------------------------------------------------------
+
+  const views = {
+    auth: $('#view-auth'),
+    ask: $('#view-ask'),
+    documents: $('#view-documents'),
+    governance: $('#view-governance'),
+    settings: $('#view-settings'),
+  };
+
+  function activateTab(name) {
+    Object.entries(views).forEach(([k, el]) => { if (k !== 'auth') (k === name ? show(el) : hide(el)); });
+    $$('.tab').forEach(t => t.classList.toggle('active', t.dataset.tab === name));
+    if (name === 'documents') refreshDocs();
+    if (name === 'governance') refreshGovernance();
+  }
+
+  $('#tabs').addEventListener('click', e => {
+    if (e.target.matches('.tab')) activateTab(e.target.dataset.tab);
+  });
+
+  // -----------------------------------------------------------------
+  // auth
+  // -----------------------------------------------------------------
+
+  const authTabs = $$('.tab-inline');
+  authTabs.forEach(t => {
+    t.addEventListener('click', () => {
+      authTabs.forEach(x => x.classList.toggle('active', x === t));
+      const which = t.dataset.auth;
+      $('#form-login').hidden = which !== 'login';
+      $('#form-signup').hidden = which !== 'signup';
+    });
+  });
+
+  $('#form-login').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const fd = new FormData(e.target);
+    try {
+      const out = await api('/users/login', { method: 'POST', json: { email: fd.get('email'), password: fd.get('password') } });
+      state.token = out.token; state.user = out.user; persistSession();
+      enterApp();
+    } catch (err) { alert('Login failed: ' + err.message); }
+  });
+
+  $('#form-signup').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const fd = new FormData(e.target);
+    try {
+      const out = await api('/users', { method: 'POST', json: { email: fd.get('email'), name: fd.get('name'), password: fd.get('password') } });
+      state.token = out.token; state.user = out.user; persistSession();
+      enterApp();
+    } catch (err) { alert('Sign-up failed: ' + err.message); }
+  });
+
+  $('#logout').addEventListener('click', () => {
+    state.token = null; state.user = null; persistSession();
+    leaveApp();
+  });
+
+  function enterApp() {
+    hide(views.auth);
+    show($('#tabs'));
+    show($('#user-chip'));
+    $('#user-chip .user-email').textContent = state.user.email;
+    activateTab('ask');
+    refreshDocs();
+    refreshHealth();
+  }
+
+  function leaveApp() {
+    show(views.auth);
+    hide($('#tabs'));
+    hide($('#user-chip'));
+    Object.entries(views).forEach(([k, el]) => { if (k !== 'auth') hide(el); });
+  }
+
+  // -----------------------------------------------------------------
+  // documents
+  // -----------------------------------------------------------------
+
+  $('#form-upload').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const file = $('#upload-file').files[0];
+    const desc = $('#upload-desc').value;
+    const cls = $('#upload-class').value;
+    if (!file) return;
+    const url = `/documents?description=${encodeURIComponent(desc)}&classification=${encodeURIComponent(cls)}`;
+    try {
+      const body = await file.arrayBuffer();
+      const out = await api(url, { method: 'POST', body, headers: { 'Content-Type': file.type || 'application/octet-stream' } });
+      state.documents.push({ id: out.id, description: desc || '(no description)', classification: out.classification, kek_id: out.kek_id });
+      renderDocs();
+      e.target.reset();
+    } catch (err) { alert('Upload failed: ' + err.message); }
+  });
+
+  async function refreshDocs() {
+    // Genie has no GET /documents list endpoint yet; we mirror local uploads.
+    renderDocs();
+  }
+
+  function renderDocs() {
+    const tbody = $('#doc-list');
+    tbody.innerHTML = '';
+    if (state.documents.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="4" class="muted">No uploads yet in this session.</td></tr>';
+    } else {
+      for (const d of state.documents) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td><code>${escapeHTML(d.id.slice(0, 8))}…</code></td>
+          <td>${escapeHTML(d.description)}</td>
+          <td><span class="badge">${escapeHTML(d.classification)}</span></td>
+          <td><code>${escapeHTML(d.kek_id || '')}</code></td>`;
+        tbody.appendChild(tr);
+      }
+    }
+    // Also re-populate the ask-doc dropdown.
+    const sel = $('#ask-doc');
+    const prev = sel.value;
+    sel.innerHTML = '';
+    if (state.documents.length === 0) {
+      sel.innerHTML = '<option value="">No documents — upload one first</option>';
+    } else {
+      for (const d of state.documents) {
+        const opt = document.createElement('option');
+        opt.value = d.id;
+        opt.textContent = `${d.description} — ${d.id.slice(0, 8)}…`;
+        sel.appendChild(opt);
+      }
+      if (prev && state.documents.find(d => d.id === prev)) sel.value = prev;
+    }
+  }
+
+  // -----------------------------------------------------------------
+  // ask (sync + streaming)
+  // -----------------------------------------------------------------
+
+  function clearEvents() { $('#events').innerHTML = ''; }
+
+  function addEvent(kind, data, klass) {
+    const li = document.createElement('li');
+    if (klass) li.classList.add(klass);
+    li.innerHTML = `<span class="event-kind">${escapeHTML(kind)}</span><span class="event-data"></span>`;
+    li.querySelector('.event-data').textContent = typeof data === 'string' ? data : JSON.stringify(data);
+    const list = $('#events');
+    list.appendChild(li);
+    list.scrollTop = list.scrollHeight;
+  }
+
+  function setBanner(text) {
+    const el = $('#ai-disclosure');
+    if (text) { el.textContent = text; show(el); } else { hide(el); }
+  }
+
+  function showReport(text) {
+    $('#report-body').textContent = text;
+    show($('#report-card'));
+  }
+
+  $('#btn-ask').addEventListener('click', async () => {
+    const docID = $('#ask-doc').value;
+    const q = $('#ask-question').value.trim();
+    if (!docID || !q) return alert('Need a document and a question.');
+    clearEvents();
+    hide($('#report-card'));
+    setBanner('');
+    addEvent('request', 'POST /v1/ask');
+    try {
+      const out = await api('/ask', { method: 'POST', json: { question: q, document_id: docID } });
+      if (out.ai_disclosure) setBanner(out.ai_disclosure);
+      addEvent('trace', out.trace_id || '');
+      addEvent('report', '(received)', 'event-report');
+      showReport(out.report || '');
+    } catch (err) {
+      addEvent('error', err.message, 'event-error');
+    }
+  });
+
+  $('#btn-ask-stream').addEventListener('click', () => {
+    const docID = $('#ask-doc').value;
+    const q = $('#ask-question').value.trim();
+    if (!docID || !q) return alert('Need a document and a question.');
+    clearEvents();
+    hide($('#report-card'));
+    setBanner('');
+
+    // EventSource doesn't allow POST or custom headers; we fall back to a
+    // fetch-streamed reader and parse SSE frames manually.
+    const ctrl = new AbortController();
+    state.activeStream = ctrl;
+    show($('#btn-stop'));
+    addEvent('request', 'POST /v1/ask/stream');
+
+    fetch(state.base.replace(/\/$/, '') + '/ask/stream', {
+      method: 'POST',
+      signal: ctrl.signal,
+      headers: {
+        'Authorization': 'Bearer ' + state.token,
+        'Content-Type': 'application/json',
+        'Accept': 'text/event-stream',
+      },
+      body: JSON.stringify({ question: q, document_id: docID }),
+    }).then(async (resp) => {
+      if (!resp.ok || !resp.body) {
+        addEvent('error', 'http ' + resp.status, 'event-error');
+        return;
+      }
+      const reader = resp.body.getReader();
+      const dec = new TextDecoder();
+      let buf = '';
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        let idx;
+        while ((idx = buf.indexOf('\n\n')) >= 0) {
+          const frame = buf.slice(0, idx);
+          buf = buf.slice(idx + 2);
+          parseSSE(frame);
+        }
+      }
+    }).catch((err) => {
+      if (err.name === 'AbortError') return;
+      addEvent('error', err.message || String(err), 'event-error');
+    }).finally(() => {
+      hide($('#btn-stop'));
+      state.activeStream = null;
+    });
+  });
+
+  $('#btn-stop').addEventListener('click', () => {
+    if (state.activeStream) state.activeStream.abort();
+  });
+
+  function parseSSE(frame) {
+    const lines = frame.split('\n');
+    let event = 'message';
+    let data = '';
+    for (const line of lines) {
+      if (line.startsWith('event:')) event = line.slice(6).trim();
+      else if (line.startsWith('data:')) data += line.slice(5).trim();
+    }
+    if (event === 'ai_disclosure') return setBanner(data);
+    if (event === 'report') {
+      addEvent('report', '(received)', 'event-report');
+      showReport(data);
+      return;
+    }
+    if (event === 'agent.handle') {
+      try { data = JSON.stringify(JSON.parse(data)); } catch (_) { /* leave as string */ }
+    }
+    addEvent(event, data);
+  }
+
+  // -----------------------------------------------------------------
+  // governance
+  // -----------------------------------------------------------------
+
+  async function refreshGovernance() {
+    try {
+      const d = await api('/disclosures');
+      $('#disclosures').textContent = JSON.stringify(d, null, 2);
+    } catch (e) { $('#disclosures').textContent = 'error: ' + e.message; }
+
+    const isAdmin = (state.user && state.user.roles || []).includes('admin');
+    if (isAdmin) {
+      try {
+        const inv = await api('/ai-inventory');
+        $('#inventory').textContent = JSON.stringify(inv, null, 2);
+      } catch (e) { $('#inventory').textContent = 'error: ' + e.message; }
+      try {
+        const bom = await api('/aibom');
+        $('#aibom').textContent = JSON.stringify(bom, null, 2);
+      } catch (e) { $('#aibom').textContent = 'error: ' + e.message; }
+      try {
+        const inc = await api('/incidents?limit=20');
+        $('#incidents').textContent = JSON.stringify(inc, null, 2);
+      } catch (e) { $('#incidents').textContent = 'error: ' + e.message; }
+    }
+  }
+
+  // -----------------------------------------------------------------
+  // settings + health
+  // -----------------------------------------------------------------
+
+  $('#settings-base').value = state.base;
+  $('#api-base').textContent = state.base;
+
+  $('#settings-save').addEventListener('click', () => {
+    const v = $('#settings-base').value.trim();
+    if (!v) return;
+    state.base = v;
+    localStorage.setItem(LS_BASE, v);
+    $('#api-base').textContent = v;
+    refreshHealth();
+  });
+
+  async function refreshHealth() {
+    const url = state.base.replace(/\/v1$/, '') + '/readyz';
+    try {
+      const resp = await fetch(url);
+      const body = await resp.text();
+      $('#health').textContent = `Readiness ${resp.status}: ${body.trim()}`;
+    } catch (e) {
+      $('#health').textContent = 'Readiness probe unreachable: ' + e.message;
+    }
+  }
+
+  // -----------------------------------------------------------------
+  // util
+  // -----------------------------------------------------------------
+
+  function escapeHTML(s) {
+    return String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+  }
+
+  // -----------------------------------------------------------------
+  // boot
+  // -----------------------------------------------------------------
+
+  if (state.token && state.user) enterApp();
+})();

--- a/pkg/web/handlers/ui/index.html
+++ b/pkg/web/handlers/ui/index.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Genie — AI Financial Assistant</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧞</text></svg>" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">
+      <span class="logo" aria-hidden="true">🧞</span>
+      <span class="brand-name">Genie</span>
+      <span class="brand-sub">AI Financial Assistant</span>
+    </div>
+    <nav class="tabs" id="tabs" hidden>
+      <button class="tab active" data-tab="ask">Ask</button>
+      <button class="tab" data-tab="documents">Documents</button>
+      <button class="tab" data-tab="governance">Governance</button>
+      <button class="tab" data-tab="settings">Settings</button>
+    </nav>
+    <div class="user" id="user-chip" hidden>
+      <span class="user-email"></span>
+      <button class="link" id="logout">Logout</button>
+    </div>
+  </header>
+
+  <main>
+    <!-- ============== AUTH ============== -->
+    <section id="view-auth" class="view">
+      <div class="card auth">
+        <h1>Welcome</h1>
+        <p class="muted">Sign in to your Genie account, or create a new one.</p>
+
+        <div class="tabs-inline">
+          <button class="tab-inline active" data-auth="login">Sign in</button>
+          <button class="tab-inline" data-auth="signup">Sign up</button>
+        </div>
+
+        <form id="form-login" class="stack">
+          <label>Email <input type="email" name="email" required autocomplete="email" /></label>
+          <label>Password <input type="password" name="password" required autocomplete="current-password" /></label>
+          <button type="submit" class="primary">Sign in</button>
+        </form>
+
+        <form id="form-signup" class="stack" hidden>
+          <label>Name <input type="text" name="name" autocomplete="name" /></label>
+          <label>Email <input type="email" name="email" required autocomplete="email" /></label>
+          <label>Password
+            <input type="password" name="password" required autocomplete="new-password" minlength="8" />
+            <small class="muted">At least 8 characters.</small>
+          </label>
+          <button type="submit" class="primary">Create account</button>
+        </form>
+
+        <p class="muted small">
+          API base: <code id="api-base">/v1</code>
+        </p>
+      </div>
+    </section>
+
+    <!-- ============== ASK ============== -->
+    <section id="view-ask" class="view" hidden>
+      <div class="grid">
+        <div class="card">
+          <h2>Ask Genie</h2>
+          <p class="muted">Pick a document, type a question, watch the multi-agent pipeline run.</p>
+
+          <label>Document
+            <select id="ask-doc"></select>
+          </label>
+
+          <label>Question
+            <textarea id="ask-question" rows="3" placeholder="Where am I overspending this month?"></textarea>
+          </label>
+
+          <div class="row">
+            <button id="btn-ask" class="primary">Ask</button>
+            <button id="btn-ask-stream" class="secondary">Ask (stream)</button>
+            <button id="btn-stop" class="link" hidden>Stop</button>
+          </div>
+
+          <p class="muted small disclosure" id="ai-disclosure"></p>
+        </div>
+
+        <div class="card">
+          <h2>Agent pipeline</h2>
+          <p class="muted">Live events from the bus.</p>
+          <ol class="events" id="events"></ol>
+        </div>
+      </div>
+
+      <div class="card report" id="report-card" hidden>
+        <h2>Report</h2>
+        <pre class="report-body" id="report-body"></pre>
+      </div>
+    </section>
+
+    <!-- ============== DOCUMENTS ============== -->
+    <section id="view-documents" class="view" hidden>
+      <div class="card">
+        <h2>Upload a transactions CSV</h2>
+        <p class="muted">The file is encrypted end-to-end with envelope AES-256-GCM before reaching Postgres.</p>
+
+        <form id="form-upload" class="stack">
+          <label>CSV file
+            <input type="file" id="upload-file" accept=".csv,text/csv" required />
+          </label>
+          <label>Description (optional)
+            <input type="text" id="upload-desc" placeholder="January statement" />
+          </label>
+          <label>Classification
+            <select id="upload-class">
+              <option value="pii" selected>pii</option>
+              <option value="internal">internal</option>
+              <option value="public">public</option>
+            </select>
+          </label>
+          <button type="submit" class="primary">Upload</button>
+        </form>
+      </div>
+
+      <div class="card">
+        <h2>Your documents</h2>
+        <table class="table">
+          <thead><tr><th>ID</th><th>Description</th><th>Classification</th><th>KEK</th></tr></thead>
+          <tbody id="doc-list"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- ============== GOVERNANCE ============== -->
+    <section id="view-governance" class="view" hidden>
+      <div class="card">
+        <h2>Public disclosures</h2>
+        <pre id="disclosures" class="json"></pre>
+      </div>
+      <div class="card">
+        <h2>AI inventory <span class="badge">admin only</span></h2>
+        <pre id="inventory" class="json">Sign in as admin to view.</pre>
+      </div>
+      <div class="card">
+        <h2>AIBOM (CycloneDX 1.6) <span class="badge">admin only</span></h2>
+        <pre id="aibom" class="json">Sign in as admin to view.</pre>
+      </div>
+      <div class="card">
+        <h2>Recent incidents <span class="badge">admin only</span></h2>
+        <pre id="incidents" class="json">Sign in as admin to view.</pre>
+      </div>
+    </section>
+
+    <!-- ============== SETTINGS ============== -->
+    <section id="view-settings" class="view" hidden>
+      <div class="card">
+        <h2>API base</h2>
+        <p class="muted">Point the UI at a different Genie instance.</p>
+        <div class="row">
+          <input type="text" id="settings-base" placeholder="https://genie.example/v1" />
+          <button id="settings-save" class="primary">Save</button>
+        </div>
+      </div>
+      <div class="card">
+        <h2>About</h2>
+        <p>
+          Genie is a Go multi-agent platform aligned with the
+          <a href="https://rbidocs.rbi.org.in/rdocs/PublicationReport/Pdfs/FREEAIR130820250A24FF2D4578453F824C72ED9F5D5851.PDF" target="_blank" rel="noopener">RBI FREE-AI</a>
+          framework. The UI is plain HTML/CSS/JS embedded in the Genie binary —
+          no Node, no build step.
+        </p>
+        <p class="muted small" id="health"></p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <span class="muted small">
+      Genie · MARA + MCP + A2A · OpenTelemetry · RBI FREE-AI aligned ·
+      <a href="https://github.com/c2siorg/genie" target="_blank" rel="noopener">github.com/c2siorg/genie</a>
+    </span>
+  </footer>
+
+  <script src="app.js" defer></script>
+</body>
+</html>

--- a/pkg/web/handlers/ui/styles.css
+++ b/pkg/web/handlers/ui/styles.css
@@ -1,0 +1,336 @@
+/* Genie UI — single stylesheet, no framework. Pairs with index.html + app.js. */
+
+:root {
+  --bg: #0c0e12;
+  --surface: #14181f;
+  --surface-2: #1a1f29;
+  --border: #232a36;
+  --text: #e6e9ef;
+  --text-dim: #98a1b1;
+  --accent: #7c5cff;
+  --accent-dim: #5b3eb1;
+  --good: #2bbf6a;
+  --warn: #e0a93b;
+  --bad: #e25c5c;
+  --code-bg: #0a0d12;
+  --radius: 10px;
+  --radius-sm: 6px;
+  --gap: 16px;
+  --gap-sm: 8px;
+  --shadow: 0 1px 0 rgba(255,255,255,0.03), 0 8px 24px rgba(0,0,0,0.35);
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "JetBrains Mono", "Roboto Mono", monospace;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #fafbfd;
+    --surface: #ffffff;
+    --surface-2: #f3f5f9;
+    --border: #e3e7ee;
+    --text: #1a1f29;
+    --text-dim: #5b6678;
+    --code-bg: #f3f5f9;
+    --shadow: 0 1px 2px rgba(0,0,0,0.04), 0 8px 24px rgba(0,0,0,0.06);
+  }
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code, pre {
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ---------- top bar ---------- */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 14px 24px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.logo { font-size: 22px; }
+.brand-name { font-weight: 700; letter-spacing: -0.01em; }
+.brand-sub { color: var(--text-dim); font-size: 13px; }
+
+.tabs {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.tab {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-dim);
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  cursor: pointer;
+}
+.tab:hover { color: var(--text); background: var(--surface-2); }
+.tab.active { color: var(--text); border-color: var(--border); background: var(--surface-2); }
+
+.user {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.user-email { color: var(--text-dim); font-size: 13px; }
+
+/* ---------- layout ---------- */
+
+main {
+  max-width: 1100px;
+  margin: 24px auto;
+  padding: 0 24px;
+}
+
+.view { display: block; }
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--gap);
+}
+@media (max-width: 800px) {
+  .grid { grid-template-columns: 1fr; }
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: var(--shadow);
+  margin-bottom: var(--gap);
+}
+
+.card h1, .card h2 {
+  margin: 0 0 8px;
+  letter-spacing: -0.01em;
+}
+.card h2 { font-size: 17px; }
+.card > p { margin: 0 0 16px; }
+
+footer {
+  border-top: 1px solid var(--border);
+  padding: 16px 24px;
+  margin-top: 32px;
+  text-align: center;
+  background: var(--surface);
+}
+
+/* ---------- forms ---------- */
+
+.stack { display: flex; flex-direction: column; gap: 14px; }
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+label small { font-weight: normal; }
+
+input, textarea, select {
+  font: inherit;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  outline: none;
+}
+input:focus, textarea:focus, select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.18);
+}
+
+button {
+  font: inherit;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+button:hover { background: var(--surface); }
+
+button.primary {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+button.primary:hover { background: var(--accent-dim); border-color: var(--accent-dim); }
+
+button.secondary {
+  background: var(--surface-2);
+  border-color: var(--border);
+}
+
+button.link {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  padding: 4px 6px;
+}
+button.link:hover { text-decoration: underline; background: transparent; }
+
+.row {
+  display: flex;
+  gap: var(--gap-sm);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.tabs-inline {
+  display: inline-flex;
+  background: var(--surface-2);
+  border-radius: var(--radius-sm);
+  padding: 4px;
+  margin-bottom: 16px;
+}
+.tab-inline {
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  padding: 6px 14px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.tab-inline.active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+
+/* ---------- auth card ---------- */
+
+.auth { max-width: 420px; margin: 64px auto; }
+
+/* ---------- events list ---------- */
+
+.events {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 320px;
+  overflow: auto;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px;
+  background: var(--code-bg);
+}
+.events li {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+.events li:last-child { border-bottom: none; }
+.event-kind {
+  color: var(--accent);
+  text-transform: lowercase;
+  flex: 0 0 auto;
+  min-width: 110px;
+}
+.event-data {
+  color: var(--text-dim);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.event-report .event-kind { color: var(--good); }
+.event-error .event-kind { color: var(--bad); }
+
+/* ---------- report ---------- */
+
+.report-body {
+  max-height: 60vh;
+  overflow: auto;
+}
+
+.disclosure {
+  border-left: 3px solid var(--accent);
+  padding-left: 10px;
+  margin-top: 12px;
+}
+
+/* ---------- table ---------- */
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.table th, .table td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+.table th { color: var(--text-dim); font-weight: 500; }
+.table tr:hover td { background: var(--surface-2); }
+.table code { font-size: 12px; }
+
+/* ---------- json blocks ---------- */
+
+pre.json {
+  max-height: 360px;
+}
+
+.badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  padding: 1px 8px;
+  border-radius: 999px;
+  vertical-align: middle;
+  margin-left: 6px;
+}
+
+/* ---------- utilities ---------- */
+
+.muted { color: var(--text-dim); }
+.small { font-size: 12px; }

--- a/pkg/web/handlers/ui_test.go
+++ b/pkg/web/handlers/ui_test.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestUI_ServesIndexAtRoot(t *testing.T) {
+	h, err := NewUI()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("content-type: %q", ct)
+	}
+	if !strings.Contains(w.Body.String(), "Genie") {
+		t.Fatal("missing Genie title in body")
+	}
+}
+
+func TestUI_ServesNamedAssets(t *testing.T) {
+	h, _ := NewUI()
+	for _, name := range []string{"styles.css", "app.js"} {
+		req := httptest.NewRequest(http.MethodGet, "/"+name, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: status %d", name, w.Code)
+		}
+		if w.Body.Len() == 0 {
+			t.Fatalf("%s: empty body", name)
+		}
+	}
+}
+
+func TestUI_BlocksTraversal(t *testing.T) {
+	h, _ := NewUI()
+	req := httptest.NewRequest(http.MethodGet, "/../../etc/passwd", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 on traversal, got %d", w.Code)
+	}
+}
+
+func TestUI_IndexRedirect(t *testing.T) {
+	h, _ := NewUI()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.IndexHTML(w, req)
+	if w.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/ui/" {
+		t.Fatalf("expected redirect to /ui/, got %q", loc)
+	}
+}

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -26,6 +26,7 @@ type Deps struct {
 	AIBOM       *handlers.AIBOM
 	Feedback    *handlers.Feedback
 	ChatWS      *handlers.ChatWS
+	UI          *handlers.UI
 	RateLimit   *mid.RateLimit // optional global limiter
 	Logger      mid.Logger
 }
@@ -43,6 +44,12 @@ func NewRouter(d Deps) http.Handler {
 	if d.Disclosures != nil {
 		// Public disclosure surface — no auth, no rate limit needed.
 		r.Get("/v1/disclosures", d.Disclosures.Get)
+	}
+
+	if d.UI != nil {
+		// Mount the embedded single-page UI under /ui/ and redirect root.
+		r.Get("/", d.UI.IndexHTML)
+		r.Mount("/ui", http.StripPrefix("/ui", d.UI))
 	}
 
 	if d.RateLimit != nil {


### PR DESCRIPTION
## Summary

Genie now ships a single-page **Web UI** embedded inside `genie-api` —
no Node, no build step, no separate static-file hosting.

After `make compose-up`, opening <http://localhost:8080/> lands the
browser on the app instead of a 404.

## What changed

- **`pkg/web/handlers/ui/`** — three static files:
  - `index.html` — auth · ask · documents · governance · settings tabs
  - `styles.css` — modern dark/light theme via `prefers-color-scheme`
  - `app.js` — vanilla JS, no framework. Uses `fetch` + manual SSE parsing
    so `/v1/ask/stream` works with the `Authorization` header (the
    browser's `EventSource` forbids custom headers).
- **`pkg/web/handlers/ui.go`** — `embed.FS` handler with
  directory-traversal protection, content-type detection per extension,
  short cache headers.
- **Router** mounts `/ui/*` and redirects bare `/` → `/ui/`. The UI sits
  outside the `/v1/*` rate-limit + auth group so assets load freely; the
  API still goes through full middleware.
- **`cmd/api/main.go`** — calls `handlers.NewUI()` and wires it into
  `web.Deps`. Logs an error (but doesn't crash) if the embedded FS fails
  to load.
- **README** — new "Web UI" section with mermaid flow + feature
  breakdown.

## Features

| Tab | What it does |
| --- | --- |
| **Sign in / Sign up** | Hits `POST /v1/users` and `POST /v1/users/login`. JWT cached in `localStorage`; survives refresh. |
| **Ask** | Picks a document, types a question, runs sync (`POST /v1/ask`) or streaming (`POST /v1/ask/stream`). Live agent events stream into a scrollable log; the final report appears below. AI disclosure banner shown when present. |
| **Documents** | Uploads via `POST /v1/documents` with classification + description. Tracks uploads in session and populates the Ask dropdown. |
| **Governance** | Public `/v1/disclosures`. Admin-only `/v1/ai-inventory`, `/v1/aibom`, `/v1/incidents` — fetched only when the JWT claims include `admin`. |
| **Settings** | Repoint the UI at a different Genie instance. Live `/readyz` probe. |

## Stats

- 8 files changed, +1,129 / 0
- 4 new handler tests, all green
- `go vet ./...` clean

## Test plan

- [x] `go test ./pkg/web/handlers/... -run TestUI`
- [x] `go vet ./...`
- [ ] Reviewer: `make compose-up`, open <http://localhost:8080>, exercise
      sign-up → upload → ask flow end-to-end.
- [ ] Reviewer: confirm streaming mode shows live `agent.handle` events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
