### PR TITLE
Make make up reachable: Go 1.25, pgvector image, env-driven LLM timeouts, smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   test:
     docker:
-      - image: cimg/go:1.22
+      - image: cimg/go:1.25
     resource_class: medium
     steps:
       - checkout
@@ -25,7 +25,7 @@ jobs:
 
   docker-build:
     docker:
-      - image: cimg/go:1.22
+      - image: cimg/go:1.25
     steps:
       - checkout
       - setup_remote_docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.25-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -6,7 +6,10 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/genie-api ./cmd/api
 
 FROM gcr.io/distroless/static:nonroot
+WORKDIR /
 COPY --from=build /out/genie-api /genie-api
+COPY config /config
+ENV GENIE_AI_POLICY=/config/ai-policy.example.yaml
 EXPOSE 8080
 USER nonroot:nonroot
 ENTRYPOINT ["/genie-api"]

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,17 @@ GO ?= go
 PKG := ./...
 BIN_DIR := bin
 
+# LLM stack defaults — Ollama is the default for both `make up` (compose) and
+# `make run-api` (local). Override any of these on the command line, e.g.
+#   make run-api GENIE_LLM=mock
+#   make run-api GENIE_OLLAMA_CHAT=llama3.1:8b
+GENIE_LLM          ?= ollama
+GENIE_OLLAMA_URL   ?= http://localhost:11434
+GENIE_OLLAMA_CHAT  ?= llama3.2:1b
+GENIE_OLLAMA_EMBED ?= nomic-embed-text
+
+export GENIE_LLM GENIE_OLLAMA_URL GENIE_OLLAMA_CHAT GENIE_OLLAMA_EMBED
+
 .PHONY: help
 help: ## Show available targets
 	@awk 'BEGIN{FS=":.*?## "}/^[a-zA-Z_-]+:.*?## /{printf "  \033[36m%-18s\033[0m %s\n",$$1,$$2}' $(MAKEFILE_LIST)
@@ -31,16 +42,91 @@ run-cli: ## Run the CLI demo (no HTTP, no Postgres)
 	$(GO) run ./cmd/genie
 
 .PHONY: run-api
-run-api: ## Run the HTTP API locally (requires GENIE_DB_DSN, GENIE_JWT_SECRET, GENIE_KEK_BASE64)
+run-api: ## Run the HTTP API locally with Ollama (requires GENIE_DB_DSN, GENIE_JWT_SECRET, GENIE_KEK_BASE64)
 	$(GO) run ./cmd/api
 
+.PHONY: run-api-mock
+run-api-mock: ## Run the HTTP API locally with the mock LLM (no Ollama dependency)
+	GENIE_LLM=mock $(GO) run ./cmd/api
+
+.PHONY: up
+up: ## One-command boot — build, start, wait for readiness, print URLs
+	@docker compose up --build -d
+	@printf "waiting for genie-api"
+	@for i in $$(seq 1 90); do \
+		if curl -fsS http://localhost:8080/readyz >/dev/null 2>&1; then \
+			printf " ready\n\n"; \
+			echo "  Genie UI:    http://localhost:8080/"; \
+			echo "  API health:  http://localhost:8080/healthz"; \
+			echo "  Disclosures: http://localhost:8080/v1/disclosures"; \
+			echo "  Grafana:     http://localhost:3000/  (admin/admin)"; \
+			echo ""; \
+			exit 0; \
+		fi; \
+		printf "."; \
+		sleep 1; \
+	done; \
+	printf " timeout\n"; \
+	docker compose logs --tail=40 genie-api; \
+	exit 1
+
+.PHONY: down
+down: ## Stop and remove the local stack
+	docker compose down -v
+
+.PHONY: smoke
+smoke: ## End-to-end smoke test against a running stack (healthz, signup, /ask, disclosures)
+	@set -euo pipefail; \
+	BASE=$${GENIE_BASE_URL:-http://localhost:8080}; \
+	EMAIL="smoke-$$(date +%s)@genie.local"; \
+	assert_field() { echo "$$1" | grep -q "\"$$2\"" || { echo "  FAIL: missing field \"$$2\" in response: $$1"; exit 1; }; }; \
+	echo "→ $$BASE/healthz"; \
+	curl -fsS "$$BASE/healthz" >/dev/null && echo "  ok"; \
+	echo "→ $$BASE/readyz"; \
+	curl -fsS "$$BASE/readyz" >/dev/null && echo "  ok"; \
+	echo "→ POST /v1/users  ($$EMAIL)"; \
+	SIGNUP=$$(curl -fsS -X POST "$$BASE/v1/users" \
+	  -H 'Content-Type: application/json' \
+	  -d "{\"email\":\"$$EMAIL\",\"name\":\"Smoke\",\"password\":\"hunter2hunter2\"}"); \
+	TOKEN=$$(printf '%s' "$$SIGNUP" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p'); \
+	[ -n "$$TOKEN" ] || { echo "  FAIL: no token in $$SIGNUP"; exit 1; }; \
+	echo "  ok (token len=$${#TOKEN})"; \
+	echo "→ GET /v1/users/me"; \
+	ME=$$(curl -fsS "$$BASE/v1/users/me" -H "Authorization: Bearer $$TOKEN"); \
+	assert_field "$$ME" email; echo "  ok"; \
+	echo "→ POST /v1/accounts"; \
+	ACC=$$(curl -fsS -X POST "$$BASE/v1/accounts" \
+	  -H "Authorization: Bearer $$TOKEN" -H 'Content-Type: application/json' \
+	  -d '{"name":"Salary","currency":"INR"}'); \
+	assert_field "$$ACC" id; echo "  ok"; \
+	echo "→ POST /v1/documents (upload tiny CSV)"; \
+	CSV=$$'date,description,category,amount,type\n2026-01-01,Salary,Income,50000,credit\n2026-01-05,Swiggy,Food,350,debit\n2026-02-01,Rent,Housing,15000,debit'; \
+	DOC=$$(printf '%s' "$$CSV" | curl -fsS -X POST "$$BASE/v1/documents?description=smoke&classification=internal" \
+	  -H "Authorization: Bearer $$TOKEN" -H 'Content-Type: text/csv' --data-binary @-); \
+	DOC_ID=$$(printf '%s' "$$DOC" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p'); \
+	[ -n "$$DOC_ID" ] || { echo "  FAIL: no doc id in $$DOC"; exit 1; }; \
+	echo "  ok (doc=$$DOC_ID)"; \
+	echo "→ warming Ollama (loading $${GENIE_OLLAMA_CHAT} into memory — once per host)"; \
+	curl -fsS -o /dev/null -m 240 -X POST "http://localhost:11434/api/generate" \
+	  -H 'Content-Type: application/json' \
+	  -d "{\"model\":\"$${GENIE_OLLAMA_CHAT}\",\"prompt\":\"hi\",\"stream\":false,\"keep_alive\":\"30m\"}" \
+	  && echo "  ok" || echo "  skipped (ollama not reachable on :11434)"; \
+	echo "→ POST /v1/ask"; \
+	ASK=$$(curl -fsS --max-time 120 -X POST "$$BASE/v1/ask" \
+	  -H "Authorization: Bearer $$TOKEN" -H 'Content-Type: application/json' \
+	  -d "{\"question\":\"Summarise this month's spending in one sentence.\",\"document_id\":\"$$DOC_ID\"}"); \
+	assert_field "$$ASK" report; echo "  ok"; \
+	echo "→ GET /v1/disclosures"; \
+	DISC=$$(curl -fsS "$$BASE/v1/disclosures"); \
+	assert_field "$$DISC" policy_version; echo "  ok"; \
+	echo ""; \
+	echo "smoke: PASS"
+
 .PHONY: compose-up
-compose-up: ## Start the local stack (Postgres, Tempo, Grafana, otel-collector, genie-api)
-	docker compose up --build -d
+compose-up: up ## Alias for `up` (kept for backward compatibility)
 
 .PHONY: compose-down
-compose-down: ## Stop and remove the local stack
-	docker compose down -v
+compose-down: down ## Alias for `down` (kept for backward compatibility)
 
 .PHONY: scaffold
 scaffold: ## Generate a new agent. Usage: make scaffold name=<id> cap=<capability> in=<intype> out=<outtype> next=<agent>

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,12 @@ build: ## Compile every binary under cmd/ into bin/
 	$(GO) build -o $(BIN_DIR)/ ./cmd/...
 
 .PHONY: test
-test: ## Run all tests
+test: ## Run all unit tests
 	$(GO) test -race $(PKG)
+
+.PHONY: e2e
+e2e: ## Run the user-simulation test against a running stack (signup → ask → disclosures)
+	$(GO) test -tags=e2e -v ./tests/sim/...
 
 .PHONY: vet
 vet: ## go vet

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -258,7 +258,7 @@ func run() error {
 			Correlator:         corr,
 			Documents:          docRepo,
 			Encryptor:          enc,
-			Timeout:            8 * time.Second,
+			Timeout:            time.Duration(envInt("GENIE_ASK_TIMEOUT", 60)) * time.Second,
 			AIDisclosureBanner: aiPolicy.Consumer.AIDisclosureBanner,
 		},
 		AskStream: &handlers.AskStream{
@@ -266,7 +266,7 @@ func run() error {
 			Tap:                eventTap,
 			Documents:          docRepo,
 			Encryptor:          enc,
-			Timeout:            10 * time.Second,
+			Timeout:            time.Duration(envInt("GENIE_STREAM_TIMEOUT", 90)) * time.Second,
 			AIDisclosureBanner: aiPolicy.Consumer.AIDisclosureBanner,
 		},
 		ChatWS: &handlers.ChatWS{
@@ -274,7 +274,7 @@ func run() error {
 			Tap:                eventTap,
 			Documents:          docRepo,
 			Encryptor:          enc,
-			Timeout:            12 * time.Second,
+			Timeout:            time.Duration(envInt("GENIE_CHATWS_TIMEOUT", 120)) * time.Second,
 			AIDisclosureBanner: aiPolicy.Consumer.AIDisclosureBanner,
 		},
 		Health: &handlers.Health{Ready: func() error {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,9 @@
 
 services:
   postgres:
-    image: postgres:16-alpine
+    # pgvector/pgvector ships Postgres 16 with the pgvector extension already
+    # installed — migration 0004 needs CREATE EXTENSION vector to succeed.
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_USER: genie
       POSTGRES_PASSWORD: genie

--- a/pkg/storage/postgres/migrations/0004_pgvector.sql
+++ b/pkg/storage/postgres/migrations/0004_pgvector.sql
@@ -15,6 +15,10 @@ CREATE TABLE IF NOT EXISTS rag_embeddings (
     PRIMARY KEY (namespace, chunk_id)
 );
 
--- ivfflat is fine for medium scale; for >1M rows switch to hnsw.
-CREATE INDEX IF NOT EXISTS idx_rag_embeddings_cosine
-    ON rag_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+-- No ANN index by default — Genie supports multiple embedder dimensions
+-- (HashEmbedder=256, Ollama nomic-embed-text=768) and ivfflat / hnsw require
+-- the column to declare a fixed dimension. Sequential scan is fine for demo
+-- corpora; once you standardize on one embedder, ALTER the column to
+-- vector(N) and add e.g.:
+--   CREATE INDEX idx_rag_embeddings_cosine ON rag_embeddings
+--     USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);

--- a/pkg/web/handlers/ui_contract_test.go
+++ b/pkg/web/handlers/ui_contract_test.go
@@ -1,0 +1,145 @@
+package handlers
+
+import (
+	"io/fs"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// readUIFile pulls a file out of the embedded UI FS via the same root the
+// production handler uses. Keeps the test honest: if NewUI's embed.FS path
+// ever drifts, this test starts failing.
+func readUIFile(t *testing.T, name string) string {
+	t.Helper()
+	ui, err := NewUI()
+	if err != nil {
+		t.Fatalf("NewUI: %v", err)
+	}
+	b, err := fs.ReadFile(ui.root, name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// TestUI_JSReferencesExistInHTML asserts every #id the JS reaches for
+// actually exists in index.html. The vanilla JS in app.js silently no-ops
+// against a missing element — without this test a stray HTML rename would
+// only surface as a runtime click that does nothing.
+func TestUI_JSReferencesExistInHTML(t *testing.T) {
+	html := readUIFile(t, "index.html")
+	js := readUIFile(t, "app.js")
+
+	// Pull every '#some-id' from JS strings.
+	// $('#foo'), $$('#bar'), getElementById('baz'), querySelector('#qux .x')
+	idRE := regexp.MustCompile(`['"]#([a-zA-Z][a-zA-Z0-9_-]*)`)
+	idGetRE := regexp.MustCompile(`getElementById\(['"]([a-zA-Z][a-zA-Z0-9_-]*)['"]`)
+
+	seen := map[string]bool{}
+	for _, m := range idRE.FindAllStringSubmatch(js, -1) {
+		seen[m[1]] = true
+	}
+	for _, m := range idGetRE.FindAllStringSubmatch(js, -1) {
+		seen[m[1]] = true
+	}
+	if len(seen) == 0 {
+		t.Fatal("regex pulled zero selectors — pattern probably broke")
+	}
+
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			needle := `id="` + id + `"`
+			if !strings.Contains(html, needle) {
+				t.Errorf("app.js references #%s but index.html has no element with id=%q", id, id)
+			}
+		})
+	}
+}
+
+// TestUI_FormFieldsMatchHandlers asserts the auth form fields use exactly the
+// names the Users handler decodes (signupRequest / loginRequest). If someone
+// renames the JSON field in users.go we want the UI test to fail too — not
+// for the user to discover at runtime that "name" went missing.
+func TestUI_FormFieldsMatchHandlers(t *testing.T) {
+	html := readUIFile(t, "index.html")
+
+	signupBlock := sliceBetween(t, html, `id="form-signup"`, `</form>`)
+	for _, want := range []string{`name="name"`, `name="email"`, `name="password"`} {
+		if !strings.Contains(signupBlock, want) {
+			t.Errorf("signup form missing %s — handler expects this JSON key", want)
+		}
+	}
+
+	loginBlock := sliceBetween(t, html, `id="form-login"`, `</form>`)
+	for _, want := range []string{`name="email"`, `name="password"`} {
+		if !strings.Contains(loginBlock, want) {
+			t.Errorf("login form missing %s — handler expects this JSON key", want)
+		}
+	}
+}
+
+// TestUI_ClassificationOptionsCoverHandlerEnum makes sure the upload form's
+// classification dropdown lists every value the documents handler accepts.
+// If protocol.Classification grows a new label, this test points at the UI
+// gap before the new label silently becomes unreachable.
+func TestUI_ClassificationOptionsCoverHandlerEnum(t *testing.T) {
+	html := readUIFile(t, "index.html")
+	uploadBlock := sliceBetween(t, html, `id="upload-class"`, `</select>`)
+
+	// These mirror the constants in pkg/protocol/classification.go that the
+	// upload handler accepts on the wire. "secret" is intentionally not in
+	// the UI — uploading secret-classified data through a browser is a
+	// policy violation, so we don't expose it.
+	wantUserSelectable := []string{"pii", "internal", "public"}
+	for _, v := range wantUserSelectable {
+		if !strings.Contains(uploadBlock, `value="`+v+`"`) {
+			t.Errorf("upload-class dropdown missing option value=%q", v)
+		}
+	}
+}
+
+// TestUI_ScriptAndStyleLinksResolve verifies index.html points at filenames
+// that actually exist in the embedded FS. Catches a typo like src="app-v2.js"
+// before deploy.
+func TestUI_ScriptAndStyleLinksResolve(t *testing.T) {
+	html := readUIFile(t, "index.html")
+	linkRE := regexp.MustCompile(`(?:src|href)="([^"/][^"]*\.(?:js|css))"`)
+
+	ui, err := NewUI()
+	if err != nil {
+		t.Fatalf("NewUI: %v", err)
+	}
+	for _, m := range linkRE.FindAllStringSubmatch(html, -1) {
+		path := m[1]
+		t.Run(path, func(t *testing.T) {
+			if _, err := fs.Stat(ui.root, path); err != nil {
+				t.Errorf("index.html references %s but file missing from embedded FS: %v", path, err)
+			}
+		})
+	}
+}
+
+// sliceBetween returns the substring of s starting at the first occurrence of
+// start and ending at the first occurrence of end after that. Used to bound
+// per-element assertions to one form/select.
+func sliceBetween(t *testing.T, s, start, end string) string {
+	t.Helper()
+	i := strings.Index(s, start)
+	if i < 0 {
+		t.Fatalf("anchor %q not found", start)
+	}
+	rest := s[i:]
+	j := strings.Index(rest, end)
+	if j < 0 {
+		t.Fatalf("closing %q after %q not found", end, start)
+	}
+	return rest[:j]
+}

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -39,63 +39,65 @@ func NewRouter(d Deps) http.Handler {
 	r.Use(mid.AccessLog(d.Logger))
 	r.Use(mid.Trace("github.com/c2siorg/genie/pkg/web"))
 
-	r.Get("/healthz", d.Health.Live)
-	r.Get("/readyz", d.Health.Readiness)
-	if d.Disclosures != nil {
-		// Public disclosure surface — no auth, no rate limit needed.
-		r.Get("/v1/disclosures", d.Disclosures.Get)
-	}
-
-	if d.UI != nil {
-		// Mount the embedded single-page UI under /ui/ and redirect root.
-		r.Get("/", d.UI.IndexHTML)
-		r.Mount("/ui", http.StripPrefix("/ui", d.UI))
-	}
-
-	if d.RateLimit != nil {
-		r.Use(d.RateLimit.Middleware)
-	}
+	// Public routes — no rate limit (k8s probes and disclosure surface
+	// must not be throttled).
+	r.Group(func(r chi.Router) {
+		r.Get("/healthz", d.Health.Live)
+		r.Get("/readyz", d.Health.Readiness)
+		if d.Disclosures != nil {
+			r.Get("/v1/disclosures", d.Disclosures.Get)
+		}
+		if d.UI != nil {
+			r.Get("/", d.UI.IndexHTML)
+			r.Mount("/ui", http.StripPrefix("/ui", d.UI))
+		}
+	})
 
 	MountPprof(r, d.Issuer)
 
-	r.Route("/v1", func(r chi.Router) {
-		r.Post("/users", d.Users.Signup)
-		r.Post("/users/login", d.Users.Login)
+	r.Group(func(r chi.Router) {
+		if d.RateLimit != nil {
+			r.Use(d.RateLimit.Middleware)
+		}
+		r.Route("/v1", func(r chi.Router) {
+			r.Post("/users", d.Users.Signup)
+			r.Post("/users/login", d.Users.Login)
 
-		r.Group(func(r chi.Router) {
-			r.Use(mid.Auth(d.Issuer))
+			r.Group(func(r chi.Router) {
+				r.Use(mid.Auth(d.Issuer))
 
-			r.Get("/users/me", d.Users.Me)
-			r.Get("/accounts", d.Accounts.List)
-			r.Post("/accounts", d.Accounts.Create)
-			r.Post("/documents", d.Documents.Upload)
-			r.Get("/documents", d.Documents.Get)
-			r.Post("/ask", d.Ask.Post)
-			if d.AskStream != nil {
-				r.Post("/ask/stream", d.AskStream.Post)
-			}
-			if d.MCPTokens != nil {
-				r.Post("/mcp/tokens", d.MCPTokens.Store)
-			}
-			if d.Incidents != nil {
-				// Reporting is open to any authenticated user (the form is
-				// meant to encourage timely disclosure — para 4.4.63). Listing
-				// is admin-only.
-				r.Post("/incidents", d.Incidents.Create)
-				r.With(mid.RequireRole(auth.RoleAdmin)).Get("/incidents", d.Incidents.List)
-			}
-			if d.Inventory != nil {
-				r.With(mid.RequireRole(auth.RoleAdmin)).Get("/ai-inventory", d.Inventory.List)
-			}
-			if d.AIBOM != nil {
-				r.With(mid.RequireRole(auth.RoleAdmin)).Get("/aibom", d.AIBOM.Get)
-			}
-			if d.Feedback != nil {
-				r.Post("/feedback", d.Feedback.Submit)
-			}
-			if d.ChatWS != nil {
-				r.Get("/chat/ws", d.ChatWS.Serve)
-			}
+				r.Get("/users/me", d.Users.Me)
+				r.Get("/accounts", d.Accounts.List)
+				r.Post("/accounts", d.Accounts.Create)
+				r.Post("/documents", d.Documents.Upload)
+				r.Get("/documents", d.Documents.Get)
+				r.Post("/ask", d.Ask.Post)
+				if d.AskStream != nil {
+					r.Post("/ask/stream", d.AskStream.Post)
+				}
+				if d.MCPTokens != nil {
+					r.Post("/mcp/tokens", d.MCPTokens.Store)
+				}
+				if d.Incidents != nil {
+					// Reporting is open to any authenticated user (the form is
+					// meant to encourage timely disclosure — para 4.4.63). Listing
+					// is admin-only.
+					r.Post("/incidents", d.Incidents.Create)
+					r.With(mid.RequireRole(auth.RoleAdmin)).Get("/incidents", d.Incidents.List)
+				}
+				if d.Inventory != nil {
+					r.With(mid.RequireRole(auth.RoleAdmin)).Get("/ai-inventory", d.Inventory.List)
+				}
+				if d.AIBOM != nil {
+					r.With(mid.RequireRole(auth.RoleAdmin)).Get("/aibom", d.AIBOM.Get)
+				}
+				if d.Feedback != nil {
+					r.Post("/feedback", d.Feedback.Submit)
+				}
+				if d.ChatWS != nil {
+					r.Get("/chat/ws", d.ChatWS.Serve)
+				}
+			})
 		})
 	})
 

--- a/pkg/web/router_test.go
+++ b/pkg/web/router_test.go
@@ -1,0 +1,149 @@
+package web
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PratikDhanave/multi-agent-reference-architecture-go/pkg/web/handlers"
+	"github.com/PratikDhanave/multi-agent-reference-architecture-go/pkg/web/mid"
+)
+
+// nopLogger satisfies mid.Logger without printing during tests.
+type nopLogger struct{}
+
+func (nopLogger) Info(string, ...any)  {}
+func (nopLogger) Error(string, ...any) {}
+
+func mustUI(t *testing.T) *handlers.UI {
+	t.Helper()
+	ui, err := handlers.NewUI()
+	if err != nil {
+		t.Fatalf("NewUI: %v", err)
+	}
+	return ui
+}
+
+// minimalDeps returns the smallest Deps that NewRouter can be invoked with
+// safely — only Health is mandatory because /healthz and /readyz are wired
+// unconditionally.
+func minimalDeps() Deps {
+	return Deps{
+		Health: &handlers.Health{},
+		Logger: nopLogger{},
+	}
+}
+
+// TestNewRouter_PanicFreeWithRateLimitAndUI guards against a regression of the
+// chi "all middlewares must be defined before routes on a mux" panic we hit
+// when the rate-limit middleware was registered after the UI mount.
+func TestNewRouter_PanicFreeWithRateLimitAndUI(t *testing.T) {
+	d := minimalDeps()
+	d.UI = mustUI(t)
+	d.RateLimit = mid.NewRateLimit(100, 10)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NewRouter panicked with RateLimit+UI: %v", r)
+		}
+	}()
+
+	if NewRouter(d) == nil {
+		t.Fatal("NewRouter returned nil")
+	}
+}
+
+// TestNewRouter_DepsPermutations sweeps the optional fields and asserts that
+// NewRouter never panics regardless of which combination is wired.
+func TestNewRouter_DepsPermutations(t *testing.T) {
+	ui := mustUI(t)
+	cases := []struct {
+		name string
+		mut  func(*Deps)
+	}{
+		{"bare", func(*Deps) {}},
+		{"+ui", func(d *Deps) { d.UI = ui }},
+		{"+ratelimit", func(d *Deps) { d.RateLimit = mid.NewRateLimit(10, 1) }},
+		{"+ui+ratelimit", func(d *Deps) {
+			d.UI = ui
+			d.RateLimit = mid.NewRateLimit(10, 1)
+		}},
+		{"+mcp", func(d *Deps) { d.MCPServer = http.NotFoundHandler() }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := minimalDeps()
+			tc.mut(&d)
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("NewRouter panicked: %v", r)
+				}
+			}()
+			if NewRouter(d) == nil {
+				t.Fatal("nil router")
+			}
+		})
+	}
+}
+
+// TestRouter_PublicRoutesUnauthenticated proves /healthz, /readyz, and the
+// UI redirect respond without an Authorization header — these endpoints
+// must stay reachable for k8s probes and the SPA landing page.
+func TestRouter_PublicRoutesUnauthenticated(t *testing.T) {
+	d := minimalDeps()
+	d.UI = mustUI(t)
+	d.RateLimit = mid.NewRateLimit(100, 10)
+
+	srv := httptest.NewServer(NewRouter(d))
+	defer srv.Close()
+
+	noFollow := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	cases := []struct {
+		path string
+		want int
+	}{
+		{"/healthz", http.StatusOK},
+		{"/readyz", http.StatusOK},
+		{"/", http.StatusFound}, // 302 → /ui/
+		{"/ui/", http.StatusOK},
+	}
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			resp, err := noFollow.Get(srv.URL + c.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", c.path, err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != c.want {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("GET %s: got %d want %d (body: %s)", c.path, resp.StatusCode, c.want, body)
+			}
+		})
+	}
+}
+
+// TestRouter_HealthzNotRateLimited verifies the rate-limit middleware doesn't
+// throttle /healthz — k8s liveness/readiness probes must always succeed,
+// even under hostile traffic that has drained the bucket.
+func TestRouter_HealthzNotRateLimited(t *testing.T) {
+	d := minimalDeps()
+	d.RateLimit = mid.NewRateLimit(1, 0) // exactly one token, no refill
+
+	srv := httptest.NewServer(NewRouter(d))
+	defer srv.Close()
+
+	for i := 0; i < 5; i++ {
+		resp, err := http.Get(srv.URL + "/healthz")
+		if err != nil {
+			t.Fatalf("GET /healthz #%d: %v", i, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET /healthz #%d: got %d, want 200 — rate limit leaked into public routes", i, resp.StatusCode)
+		}
+	}
+}

--- a/tests/sim/sim_test.go
+++ b/tests/sim/sim_test.go
@@ -1,0 +1,310 @@
+//go:build e2e
+
+// Package sim contains the user-simulation test that drives a real Genie
+// server end-to-end the way the embedded SPA would: signup → /users/me →
+// create account → upload encrypted CSV → /v1/ask → /v1/disclosures.
+//
+// The default build tag keeps it out of `go test ./...` because it needs a
+// live server. Run it with:
+//
+//	make e2e
+//	# or
+//	go test -tags=e2e -v ./tests/sim/...
+//
+// Targets a live stack on http://localhost:8080 by default; override with
+// GENIE_BASE_URL.
+package sim
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const sampleCSV = `date,description,category,amount,type
+2026-01-01,Salary,Income,50000,credit
+2026-01-05,Swiggy,Food,350,debit
+2026-02-01,Rent,Housing,15000,debit
+`
+
+// client wraps the bits of net/http we need with the user's bearer token
+// auto-attached. Stays a struct so subtests can hang test state off it.
+type client struct {
+	t       *testing.T
+	base    string
+	token   string
+	user    user
+	httpCli *http.Client
+}
+
+type user struct {
+	ID    string   `json:"id"`
+	Email string   `json:"email"`
+	Name  string   `json:"name"`
+	Roles []string `json:"roles"`
+}
+
+type signupResp struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expires_at"`
+	User      user   `json:"user"`
+}
+
+type uploadResp struct {
+	ID             string `json:"id"`
+	Classification string `json:"classification"`
+	KEKID          string `json:"kek_id"`
+}
+
+type askResp struct {
+	TraceID      string `json:"trace_id"`
+	Report       string `json:"report"`
+	AIDisclosure string `json:"ai_disclosure"`
+}
+
+type disclosuresResp struct {
+	PolicyVersion string `json:"policy_version"`
+	HomeRegion    string `json:"home_region"`
+}
+
+func newClient(t *testing.T) *client {
+	base := os.Getenv("GENIE_BASE_URL")
+	if base == "" {
+		base = "http://localhost:8080"
+	}
+	c := &client{
+		t:       t,
+		base:    base,
+		httpCli: &http.Client{Timeout: 180 * time.Second},
+	}
+	c.requireServerUp()
+	return c
+}
+
+// requireServerUp skips the whole test if /readyz is unreachable so this
+// file doesn't false-fail when the user runs the suite without a stack.
+func (c *client) requireServerUp() {
+	resp, err := http.Get(c.base + "/readyz")
+	if err != nil {
+		c.t.Skipf("no Genie server at %s (%v) — run `make up` first", c.base, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		c.t.Skipf("Genie server at %s is not ready (status=%d)", c.base, resp.StatusCode)
+	}
+}
+
+func (c *client) do(method, path string, body io.Reader, contentType string) ([]byte, int) {
+	c.t.Helper()
+	req, err := http.NewRequest(method, c.base+path, body)
+	if err != nil {
+		c.t.Fatalf("build %s %s: %v", method, path, err)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.httpCli.Do(req)
+	if err != nil {
+		c.t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return b, resp.StatusCode
+}
+
+func (c *client) postJSON(path string, payload any) ([]byte, int) {
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		c.t.Fatalf("marshal %s: %v", path, err)
+	}
+	return c.do(http.MethodPost, path, bytes.NewReader(buf), "application/json")
+}
+
+func (c *client) get(path string) ([]byte, int) {
+	return c.do(http.MethodGet, path, nil, "")
+}
+
+func assertStatus(t *testing.T, got, want int, body []byte) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("status=%d want=%d body=%s", got, want, string(body))
+	}
+}
+
+// TestUserJourney walks the exact flow a real user would take through the
+// SPA. Each step depends on state established by the prior step, so the
+// subtests run sequentially.
+func TestUserJourney(t *testing.T) {
+	c := newClient(t)
+	email := fmt.Sprintf("sim-%d@genie.local", time.Now().UnixNano())
+	var docID string
+
+	t.Run("signup", func(t *testing.T) {
+		body, status := c.postJSON("/v1/users", map[string]string{
+			"email": email, "name": "Sim", "password": "hunter2hunter2",
+		})
+		assertStatus(t, status, http.StatusCreated, body)
+		var got signupResp
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode signup: %v", err)
+		}
+		if got.Token == "" {
+			t.Fatalf("empty token: %s", body)
+		}
+		if got.User.Email != email {
+			t.Errorf("user.email=%q want %q", got.User.Email, email)
+		}
+		c.token = got.Token
+		c.user = got.User
+	})
+
+	t.Run("users/me", func(t *testing.T) {
+		body, status := c.get("/v1/users/me")
+		assertStatus(t, status, http.StatusOK, body)
+		var got user
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode me: %v", err)
+		}
+		if got.ID != c.user.ID {
+			t.Errorf("me.id=%q want %q", got.ID, c.user.ID)
+		}
+	})
+
+	t.Run("create account", func(t *testing.T) {
+		body, status := c.postJSON("/v1/accounts", map[string]string{
+			"name": "Salary", "currency": "INR",
+		})
+		assertStatus(t, status, http.StatusCreated, body)
+		var got struct{ ID string `json:"id"` }
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode account: %v", err)
+		}
+		if got.ID == "" {
+			t.Fatalf("empty account id: %s", body)
+		}
+	})
+
+	t.Run("upload document", func(t *testing.T) {
+		// Use classification=internal because the supervisor's RBAC ceiling
+		// rejects pii-labelled inputs by default (see protocol.Classification).
+		body, status := c.do(http.MethodPost,
+			"/v1/documents?description=sim&classification=internal",
+			strings.NewReader(sampleCSV), "text/csv")
+		assertStatus(t, status, http.StatusCreated, body)
+		var got uploadResp
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode upload: %v", err)
+		}
+		if got.ID == "" {
+			t.Fatalf("empty doc id: %s", body)
+		}
+		if got.KEKID == "" {
+			t.Errorf("empty kek_id — envelope encryption metadata missing")
+		}
+		docID = got.ID
+	})
+
+	t.Run("ask", func(t *testing.T) {
+		if docID == "" {
+			t.Fatal("doc not uploaded — earlier subtest failed")
+		}
+		body, status := c.postJSON("/v1/ask", map[string]string{
+			"question":    "Summarise this month's spending in one sentence.",
+			"document_id": docID,
+		})
+		assertStatus(t, status, http.StatusOK, body)
+		var got askResp
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode ask: %v", err)
+		}
+		if got.Report == "" {
+			t.Fatal("empty report — agent pipeline produced no output")
+		}
+		if got.TraceID == "" {
+			t.Errorf("missing trace_id — observability metadata stripped")
+		}
+		// AI disclosure banner is a regulatory requirement (Rec 18); the test
+		// fails if it's not attached so the legal team gets a CI signal.
+		if got.AIDisclosure == "" {
+			t.Errorf("missing ai_disclosure banner — Rec 18 / Sutra 2 violation")
+		}
+		t.Logf("trace=%s disclosure=%q report-len=%d", got.TraceID, got.AIDisclosure, len(got.Report))
+	})
+
+	t.Run("disclosures public", func(t *testing.T) {
+		// Save the token, hit /v1/disclosures unauthenticated, restore. The
+		// disclosure surface is supposed to be reachable without login.
+		saved := c.token
+		c.token = ""
+		body, status := c.get("/v1/disclosures")
+		c.token = saved
+
+		assertStatus(t, status, http.StatusOK, body)
+		var got disclosuresResp
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode disclosures: %v", err)
+		}
+		if got.PolicyVersion == "" {
+			t.Errorf("empty policy_version — Annexure V policy not loaded")
+		}
+		if got.HomeRegion == "" {
+			t.Errorf("empty home_region — sovereignty metadata missing")
+		}
+	})
+}
+
+// TestPublicEndpointsNoAuth proves the unauthenticated surface (healthz,
+// readyz, /, /ui/) really is reachable without a token. Guards against
+// someone accidentally wrapping these in auth middleware.
+func TestPublicEndpointsNoAuth(t *testing.T) {
+	c := newClient(t)
+	noFollow := &http.Client{
+		Timeout: 10 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	cases := []struct {
+		path string
+		want int
+	}{
+		{"/healthz", http.StatusOK},
+		{"/readyz", http.StatusOK},
+		{"/", http.StatusFound},
+		{"/ui/", http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			resp, err := noFollow.Get(c.base + tc.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", tc.path, err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != tc.want {
+				body, _ := io.ReadAll(resp.Body)
+				t.Errorf("GET %s: got %d want %d body=%s", tc.path, resp.StatusCode, tc.want, body)
+			}
+		})
+	}
+}
+
+// TestAuthRejectsUnauthenticated proves /v1/users/me requires the JWT.
+// Catches an obvious-but-disastrous regression where auth middleware gets
+// disabled.
+func TestAuthRejectsUnauthenticated(t *testing.T) {
+	c := newClient(t)
+	body, status := c.get("/v1/users/me")
+	if status != http.StatusUnauthorized {
+		t.Fatalf("GET /v1/users/me without token: got %d want 401, body=%s", status, body)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix four sequential failures that prevented `make up && open http://localhost:8080` from working out of the box.
- Add `make up` / `make down` / `make smoke` so the whole loop is one command.
- Make Ollama the default LLM for both compose and `make run-api` (`run-api-mock` is the offline path).

## What was broken
| Step | Failure |
|------|---------|
| Image build | `go.mod requires go >= 1.25.0` (Dockerfile + CI were on 1.22) |
| Postgres start | `extension "vector" is not available` (image was `postgres:16-alpine`) |
| Migration 0004 | `column does not have dimensions` (ivfflat requires a fixed `vector(N)`; Genie supports both 256-d and 768-d embedders) |
| API startup | `open config/ai-policy.example.yaml: no such file or directory` (distroless image didn't ship the `config/` tree) |
| Router boot | `chi: all middlewares must be defined before routes on a mux` (rate-limit `r.Use` was after the UI mount) |
| `/v1/ask` | 504 on first call — 8s hard-coded timeout was tuned for the mock provider, too tight for Ollama cold-start + multi-agent pipeline |

## What changed
**Container / infra**
- `Dockerfile`: bump to `golang:1.25-alpine`, `WORKDIR /`, `COPY config /config`, `ENV GENIE_AI_POLICY=/config/ai-policy.example.yaml`
- `.circleci/config.yml`: bump to `cimg/go:1.25`
- `docker-compose.yaml`: postgres image → `pgvector/pgvector:pg16`
- `pkg/storage/postgres/migrations/0004_pgvector.sql`: drop the ivfflat index, document the trade-off

**Code**
- `pkg/web/router.go`: restructure with `r.Group()` so `r.Use(d.RateLimit.Middleware)` is declared before any routes
- `cmd/api/main.go`: `/v1/ask`, `/v1/ask/stream`, `/v1/chat/ws` timeouts now env-driven (`GENIE_ASK_TIMEOUT` / `GENIE_STREAM_TIMEOUT` / `GENIE_CHATWS_TIMEOUT`) with Ollama-friendly defaults of 60s / 90s / 120s (was 8 / 10 / 12)

**Makefile**
- `make up` — build, start, poll `/readyz`, print Genie UI / health / disclosures / Grafana URLs
- `make down` — `docker compose down -v`
- `make smoke` — signup → JWT → \`/v1/users/me\` → \`/v1/accounts\` → upload CSV (\`internal\` classification, correct \`date,description,category,amount,type\` schema) → warm Ollama (\`keep_alive=30m\`) → \`/v1/ask\` → \`/v1/disclosures\`. Uses only \`curl + sed + grep\`, no \`jq\` dependency.
- Ollama default vars exported at top (\`GENIE_LLM=ollama\`, \`GENIE_OLLAMA_URL/CHAT/EMBED\`), all \`?=\` overridable. \`make run-api-mock\` for the offline path.

## Test plan
- [x] \`make up\` boots the stack and \`/readyz\` returns 200
- [x] \`curl http://localhost:8080/\` → 302 → \`/ui/\` serves the embedded SPA
- [x] \`make smoke\` passes end-to-end against the Ollama-backed stack (full supervisor pipeline through ingestor → normalizer → enricher → analyzer → forecaster → anomaly_detector → recommender → reporter)
- [x] \`go build ./...\` clean
- [x] \`make down\` tears it back down

🤖 Generated with [Claude Code](https://claude.com/claude-code)